### PR TITLE
bump kotlin version and fix hosted flow example

### DIFF
--- a/idv/mobile-android-onboarding-components/app/build.gradle.kts
+++ b/idv/mobile-android-onboarding-components/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -31,11 +33,14 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
     buildFeatures {
         compose = true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
     }
 }
 
@@ -56,5 +61,5 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
-    implementation("com.onefootprint.native_onboarding_components:onboarding_components-android:1.3.0")
+    implementation("com.onefootprint.native_onboarding_components:onboarding_components-android:1.3.3")
 }

--- a/idv/mobile-android-onboarding-components/app/src/main/java/com/example/footprintandroidonboardingcomponentsdemo/MainActivity.kt
+++ b/idv/mobile-android-onboarding-components/app/src/main/java/com/example/footprintandroidonboardingcomponentsdemo/MainActivity.kt
@@ -284,6 +284,7 @@ fun Init(
                         )
                         FootprintHosted.launchHosted(
                             context = context,
+                            publicKey = "pb_test_Nza8oVYDBlrIqrQrNCbKRB",
                             onComplete = { token: String ->
                                 println("VerificationResult: The flow has completed. The validation token is $token")
                             },

--- a/idv/mobile-android-onboarding-components/gradle/libs.versions.toml
+++ b/idv/mobile-android-onboarding-components/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.7.2"
-kotlin = "2.0.0"
+kotlin = "2.3.20"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"


### PR DESCRIPTION
This PR bumps the kotlin version to the latest and fixes an issue with the hosted flow where the public key parameter was missing. Also bumps the android onboarding components to the latest released version.